### PR TITLE
Tests/generation rate

### DIFF
--- a/test/sprout.ts
+++ b/test/sprout.ts
@@ -17,19 +17,11 @@ import {
 } from "./util";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
-interface UserState {
-  stakeBalance: BigNumber;
-  lastDeposit: BigNumber;
-  lastMint: BigNumber;
-}
-
 describe("SproutToken", function () {
   let ecoToken: EcoFiToken;
   let sproutToken: SproutToken;
   let ecoMultisig: SignerWithAddress;
   let ecoTestAccount: SignerWithAddress;
-
-  const MIN_STAKE_DURATION_SECONDS = 7776000;
 
   // context
   let stakeBalance: BigNumber;
@@ -45,7 +37,7 @@ describe("SproutToken", function () {
     await ecoToken.deployed();
 
     // send 1000 tokens to eco_test_account
-    const transfer = await ecoToken
+    await ecoToken
       .connect(ecoMultisig)
       .transfer(ecoTestAccount.address, Amounts._1000_E18);
 
@@ -60,9 +52,9 @@ describe("SproutToken", function () {
 
   it("deposits 100 ECO from test account", async function () {
     // approve, stake
-    const approve = await ecoToken
+    await ecoToken
       .connect(ecoTestAccount)
-      .approve(await sproutToken.address, Amounts._100_E18);
+      .approve(sproutToken.address, Amounts._100_E18);
     const tx = await sproutToken
       .connect(ecoTestAccount)
       .stakeDeposit(Amounts._100_E18);

--- a/test/util.ts
+++ b/test/util.ts
@@ -12,7 +12,7 @@ export namespace Amounts {
 export const SECONDS_IN_A_DAY = 24 * 60 * 60;
 
 export async function currentBlockTimestamp(): Promise<number> {
-  const number = ethers.provider.getBlockNumber();
+  const number = await ethers.provider.send("eth_blockNumber", []);
   const block = ethers.provider.getBlock(number);
   return (await block).timestamp;
 }
@@ -27,7 +27,7 @@ export function closeTo(a: BigNumber, b:BigNumber, delta: number): boolean {
 }
 
 const WAD_RAY_RATIO = BigNumber.from(1e9);
-const RAY = BigNumber.from(10).pow(27);
+export const RAY = BigNumber.from(10).pow(27);
 
 function rayDiv(a: BigNumber, b: BigNumber) {
   return b.div(2).add(a.mul(RAY)).div(b)


### PR DESCRIPTION
Direct tests for the generation rate, rather than recomputing the same values and hoping we haven't made mistakes.

We can see with these that the generation caps out at `300.0000000000000000093824000 %`  rather than precisely `300 %`. @tshabs is this an issue?

The changes made to the contract seem to have no effect on the gas costs outside of _reducing_ the deployment cost by a negligible amount.

I had to use `evm_snapshot` and `evm_revert` since the previous tests (i.e. `correctly computes the SPRT Generation amount`) left the EVM far into the future relative to the last deposit. The call to `ethers.provider.getBlockNumber()` in the `currentBlockTimestamp` function did not return the correct number after the revert so it was changed to `ethers.provider.send("eth_blockNumber", [])`.